### PR TITLE
Fix error about option '-p' and 'usage'

### DIFF
--- a/Docker/scripts_custardPy/custardpy_cooler_HiC
+++ b/Docker/scripts_custardPy/custardpy_cooler_HiC
@@ -99,15 +99,15 @@ fi
 
 if test "$build" = ""; then
     echo "Error: specify genome build (-b)."
-    exit 0
+    exit 1
 fi
 if test "$gt" = ""; then
     echo "Error: specify genome table (-g)."
-    exit 0
+    exit 1
 fi
 if test "$genome" = ""; then
     echo "Error: specify genome (-f)."
-    exit 0
+    exit 1
 fi
 
 if test $enzyme = "HindIII"; then
@@ -146,15 +146,15 @@ echo "Analyzing $fqdir..."
 #    done
 #fi
 
-if [ -z "$stage_pairs" ] && [ -z "$stage_postproc" ]; then
+if [ "$stage_all" = 1 ] || [ "$stage_map" = 1 ]; then
     mapping_reads_bwa $fqdir $odir $prefix $index_bwa $ncore $postfix1 $postfix2
 fi
 
-if [ -z "$stage_map" ] && [ -z "$stage_postproc" ]; then
+if [ "$stage_all" = 1 ] || [ "$stage_pairs" = 1 ]; then
     parse_pairtools $odir $gt $qthre $restrictionsite $enzymelen
 fi
 
-if [ -z "$stage_map" ] && [ -z "$stage_pairs" ]; then
+if [ "$stage_all" = 1 ] || [ "$stage_postproc" = 1 ]; then
     pair=$odir/pairs/dedup.restricted.q$qthre.pairs.gz
     gen_cool_hic $odir $gt $prefix $binsize_multi $max_distance $max_split $qthre $pair
 fi

--- a/Docker/scripts_custardPy/custardpy_cooler_HiC
+++ b/Docker/scripts_custardPy/custardpy_cooler_HiC
@@ -68,7 +68,7 @@ while getopts "i:g:f:e:b:o:q:p:S:m:n:r:x:h" opt; do
                 ;;
             *)
                 echo "Error: Specify 1 or 2 to the option '-x'."
-                printHelpAndExi
+                printHelpAndExit
                 exit 1
                 ;;
            esac

--- a/Docker/scripts_custardPy/custardpy_cooler_HiC
+++ b/Docker/scripts_custardPy/custardpy_cooler_HiC
@@ -5,7 +5,7 @@ printHelpAndExit() {
     echo '  fastqdir: Directory that contains input fastq files (e.g., "fastq/")'
     echo "  odir: Name of output directory"
     echo -e "\n  Options:"
-    echo "    -S stage : steps to be executed [all|pairs|postproc] (default: all)"
+    echo "    -S stage : steps to be executed [all|map|pairs|postproc] (default: all)"
     echo "       all: execute all process (default)"
     echo "       map: map reads and exit"
     echo "       pairs: generate .pair file from map file"
@@ -110,7 +110,7 @@ if test "$genome" = ""; then
     exit 1
 fi
 
-if test $enzyme = "HindIII"; then
+if test "$enzyme" = "HindIII"; then
     enzymelen=6
 else
     enzymelen=4

--- a/Docker/scripts_custardPy/custardpy_cooler_HiC
+++ b/Docker/scripts_custardPy/custardpy_cooler_HiC
@@ -67,8 +67,8 @@ while getopts "i:g:f:e:b:o:q:p:S:m:n:r:x:h" opt; do
                 postfix2=_R2.fastq.gz
                 ;;
             *)
-                echo "Error: Specify 1 or 2 to the option '-p'."
-                usage
+                echo "Error: Specify 1 or 2 to the option '-x'."
+                printHelpAndExi
                 exit 1
                 ;;
            esac

--- a/Docker/scripts_custardPy/custardpy_cooler_MicroC
+++ b/Docker/scripts_custardPy/custardpy_cooler_MicroC
@@ -95,15 +95,15 @@ fi
 
 if test "$gt" = ""; then
     echo "Error: specify genome table (-g)."
-    exit 0
+    exit 1
 fi
 if test "$tool" != "bwa" -a "$tool" != "chromap"; then
     echo "Error: specify bwa or chromap for -t."
-    exit 0
+    exit 1
 fi
 if test "$genome" = ""; then
     echo "Error: specify genome fasta (-f)."
-    exit 0
+    exit 1
 fi
 
 ex(){ echo $1; eval $1; }

--- a/Docker/scripts_custardPy/custardpy_cooler_MicroC
+++ b/Docker/scripts_custardPy/custardpy_cooler_MicroC
@@ -65,7 +65,7 @@ while getopts "i:t:g:f:o:q:p:S:m:n:r:hx:" opt; do
                 ;;
             *)
                 echo "Error: Specify 1 or 2 to the option '-x'."
-                printHelpAndExi
+                printHelpAndExit
                 exit 1
                 ;;
            esac

--- a/Docker/scripts_custardPy/custardpy_cooler_MicroC
+++ b/Docker/scripts_custardPy/custardpy_cooler_MicroC
@@ -64,8 +64,8 @@ while getopts "i:t:g:f:o:q:p:S:m:n:r:hx:" opt; do
                 postfix2=_R2.fastq.gz
                 ;;
             *)
-                echo "Error: Specify 1 or 2 to the option '-p'."
-                usage
+                echo "Error: Specify 1 or 2 to the option '-x'."
+                printHelpAndExi
                 exit 1
                 ;;
            esac


### PR DESCRIPTION
I've found the cause of the error and several points for correction, so I am sending this request.

When I run following command, the below error occurs. 

#command
$sing custardpy_cooler -g $gt -f $genome -e $enzyme -b $build -i $bwaindex -p $ncore -x $fqpost -m $max_distance $fqdir $cell/$prefix

#error
Error: Specify 1 or 2 to the option '-p'.
/opt/scripts_custardPy/custardpy_cooler: line 72: usage: command not found
